### PR TITLE
update Mongo to 8 (#96)

### DIFF
--- a/account-service/src/test/java/pl/piomin/microservices/advanced/account/config/AccountContainersConfiguration.java
+++ b/account-service/src/test/java/pl/piomin/microservices/advanced/account/config/AccountContainersConfiguration.java
@@ -12,7 +12,7 @@ public class AccountContainersConfiguration {
     @Bean
     @ServiceConnection
     public MongoDBContainer mongodbContainer() {
-        return new MongoDBContainer(DockerImageName.parse("mongo:4.4"));
+        return new MongoDBContainer(DockerImageName.parse("mongo:8.0"));
     }
 
 }

--- a/account-service/src/test/java/pl/piomin/microservices/advanced/account/repository/AccountRepositoryTest.java
+++ b/account-service/src/test/java/pl/piomin/microservices/advanced/account/repository/AccountRepositoryTest.java
@@ -24,7 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class AccountRepositoryTest {
 
     @Container
-    static MongoDBContainer mongoDBContainer = new MongoDBContainer("mongo:4.4");
+    static MongoDBContainer mongoDBContainer = new MongoDBContainer("mongo:8.0");
 
     @DynamicPropertySource
     static void registerMongoProperties(DynamicPropertyRegistry registry) {

--- a/customer-service/src/test/java/pl/piomin/microservices/advanced/customer/CustomerControllerTests.java
+++ b/customer-service/src/test/java/pl/piomin/microservices/advanced/customer/CustomerControllerTests.java
@@ -38,7 +38,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class CustomerControllerTests {
 
     @Container
-    static MongoDBContainer mongoDBContainer = new MongoDBContainer("mongo:4.4");
+    static MongoDBContainer mongoDBContainer = new MongoDBContainer("mongo:8.0");
 
     @DynamicPropertySource
     static void registerMongoProperties(DynamicPropertyRegistry registry) {

--- a/customer-service/src/test/java/pl/piomin/microservices/advanced/customer/CustomerRepositoryTests.java
+++ b/customer-service/src/test/java/pl/piomin/microservices/advanced/customer/CustomerRepositoryTests.java
@@ -26,7 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class CustomerRepositoryTests {
 
     @Container
-    static MongoDBContainer mongoDBContainer = new MongoDBContainer("mongo:4.4");
+    static MongoDBContainer mongoDBContainer = new MongoDBContainer("mongo:8.0");
 
     @DynamicPropertySource
     static void registerMongoProperties(DynamicPropertyRegistry registry) {

--- a/product-service/src/test/java/pl/piomin/microservices/advanced/product/ProductRepositoryTests.java
+++ b/product-service/src/test/java/pl/piomin/microservices/advanced/product/ProductRepositoryTests.java
@@ -27,7 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class ProductRepositoryTests {
 
     @Container
-    static MongoDBContainer mongoDBContainer = new MongoDBContainer("mongo:4.4");
+    static MongoDBContainer mongoDBContainer = new MongoDBContainer("mongo:8.0");
 
     @DynamicPropertySource
     static void registerMongoProperties(DynamicPropertyRegistry registry) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the MongoDB version used in test environments from 4.4 to 8.0 across account, customer, and product services. This ensures tests run against the latest MongoDB version. No changes were made to test logic or application features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->